### PR TITLE
Limbs Fly Off

### DIFF
--- a/ArmAndLeg/Assets/Prefabs/ArmPrefab.prefab
+++ b/ArmAndLeg/Assets/Prefabs/ArmPrefab.prefab
@@ -20,6 +20,7 @@ GameObject:
   m_Component:
   - 4: {fileID: 4000012867780630}
   - 212: {fileID: 212000012701805192}
+  - 114: {fileID: 114000014155718316}
   m_Layer: 0
   m_Name: ArmPrefab
   m_TagString: Untagged
@@ -40,6 +41,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!114 &114000014155718316
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012771716612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92fc5daefffd9154ab38ae11768ca377, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!212 &212000012701805192
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/ArmAndLeg/Assets/Prefabs/LimbPrefab.prefab
+++ b/ArmAndLeg/Assets/Prefabs/LimbPrefab.prefab
@@ -9,31 +9,31 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1000011804989988}
+  m_RootGameObject: {fileID: 1000013572252958}
   m_IsPrefabParent: 1
---- !u!1 &1000011804989988
+--- !u!1 &1000013572252958
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 4000010702211374}
-  - 212: {fileID: 212000013986602036}
-  - 114: {fileID: 114000010657218380}
+  - 4: {fileID: 4000013289279286}
+  - 212: {fileID: 212000014038863182}
+  - 50: {fileID: 50000012700813216}
   m_Layer: 0
-  m_Name: LegPrefab
+  m_Name: LimbPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4000010702211374
+--- !u!4 &4000013289279286
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011804989988}
+  m_GameObject: {fileID: 1000013572252958}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -41,23 +41,29 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
---- !u!114 &114000010657218380
-MonoBehaviour:
+--- !u!50 &50000012700813216
+Rigidbody2D:
+  serializedVersion: 2
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011804989988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 92fc5daefffd9154ab38ae11768ca377, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!212 &212000013986602036
+  m_GameObject: {fileID: 1000013572252958}
+  m_UseAutoMass: 1
+  m_Mass: 1
+  m_LinearDrag: 2
+  m_AngularDrag: 1
+  m_GravityScale: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!212 &212000014038863182
 SpriteRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011804989988}
+  m_GameObject: {fileID: 1000013572252958}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0

--- a/ArmAndLeg/Assets/Prefabs/LimbPrefab.prefab.meta
+++ b/ArmAndLeg/Assets/Prefabs/LimbPrefab.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f821fcc127ec2049a28a9c0e291df67
+timeCreated: 1477110912
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ArmAndLeg/Assets/Scripts/EnemyController.cs
+++ b/ArmAndLeg/Assets/Scripts/EnemyController.cs
@@ -1,37 +1,43 @@
-﻿using UnityEngine;
-using System.Collections;
-using Items;
+﻿using Items;
+
+using UnityEngine;
+
 public class EnemyController : MonoBehaviour
 {
+    public Inventory m_Inventory;
+
+    public GameObject armPrefab;
+    public GameObject legPrefab;
 
     // Use this for initialization
     void Start()
     {
-        GameObject armLeftobj = BuildLimb(armPrefab, new Arm(), true);
-        GameObject armRightobj = BuildLimb(armPrefab, new Arm());
-        GameObject legRightobj = BuildLimb(legPrefab, new Leg(), true);
-        GameObject legLeftobj = BuildLimb(legPrefab, new Leg());
+        var armLeftobj = BuildLimb(armPrefab, new Arm(), true);
+        var armRightobj = BuildLimb(armPrefab, new Arm());
+        var legRightobj = BuildLimb(legPrefab, new Leg(), true);
+        var legLeftobj = BuildLimb(legPrefab, new Leg());
     }
 
-    GameObject BuildLimb(GameObject template, Limb limb, bool flipX = false, bool flipY = false)
+    private GameObject BuildLimb(Object template, Limb limb, bool flipX = false, bool flipY = false)
     {
-        GameObject obj = Instantiate(template, transform) as GameObject;
-        LimbBehaviour objComp = obj.AddComponent<LimbBehaviour>();
+        var obj = Instantiate(template, transform) as GameObject;
+        if (!obj)
+            return null;
+
+        var objComp = obj.AddComponent<EnemyLimbBehaviour>();
+
         objComp.Init(limb);
+
         obj.GetComponent<SpriteRenderer>().flipX = flipX;
         obj.GetComponent<SpriteRenderer>().flipY = flipY;
+
         m_Inventory.AddLimb(limb);
 
         return obj;
     }
 
-    // Update is called once per frame
-    public Inventory m_Inventory;
-    public GameObject armPrefab;
-    public GameObject legPrefab;
-
     public void OnCollisionEnter2D(Collision2D collision)
-    {        
-        m_Inventory.PopArm(transform);
+    {
+        m_Inventory.PopArm(transform.position);
     }
 }

--- a/ArmAndLeg/Assets/Scripts/EnemyLimbBehaviour.cs
+++ b/ArmAndLeg/Assets/Scripts/EnemyLimbBehaviour.cs
@@ -1,0 +1,31 @@
+﻿using Items;
+
+using UnityEngine;
+
+public class EnemyLimbBehaviour : MonoBehaviour
+{
+    [SerializeField]
+    private Limb m_Limb;
+
+    public Limb limb
+    {
+        get { return m_Limb; }
+    }
+
+    public bool Init(Limb newLimb)
+    {
+        m_Limb = newLimb;
+
+        // Attach to the event
+        m_Limb.inInventoryEvent.AddListener(
+            inInventory =>
+            {
+                if (!inInventory)
+                    Destroy(gameObject);
+            });
+
+        return true;
+    }
+
+
+}

--- a/ArmAndLeg/Assets/Scripts/EnemyLimbBehaviour.cs.meta
+++ b/ArmAndLeg/Assets/Scripts/EnemyLimbBehaviour.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 92fc5daefffd9154ab38ae11768ca377
+timeCreated: 1477109648
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ArmAndLeg/Assets/Scripts/Inventory.cs
+++ b/ArmAndLeg/Assets/Scripts/Inventory.cs
@@ -91,43 +91,43 @@ public class Inventory
         return true;
     }
 
-    public bool PopLimb(Transform parentTransform, int popNumber = 1)
+    public bool PopLimb(Vector3 position, int popNumber = 1)
     {
         if (popNumber > m_Limbs.Count)
             return false;
 
         for (var i = 0; i < popNumber; ++i)
-            if (!RemoveLimb(m_Limbs.Last(), parentTransform))
+            if (!RemoveLimb(m_Limbs.Last(), position))
                 return false;
 
         return true;
     }
 
-    public bool PopArm(Transform parentTransform, int popNumber = 1)
+    public bool PopArm(Vector3 position, int popNumber = 1)
     {
         if (popNumber > armCount)
             return false;
 
         for (var i = 0; i < popNumber; ++i)
-            if (!RemoveLimb(arms.Last(), parentTransform))
+            if (!RemoveLimb(arms.Last(), position))
                 return false;
 
         return true;
     }
 
-    public bool PopLeg(Transform parentTransform, int popNumber = 1)
+    public bool PopLeg(Vector3 position, int popNumber = 1)
     {
         if (popNumber > legCount)
             return false;
 
         for (var i = 0; i < popNumber; ++i)
-            if (!RemoveLimb(legs.Last(), parentTransform))
+            if (!RemoveLimb(legs.Last(), position))
                 return false;
 
         return true;
     }
 
-    public bool RemoveLimb(Limb limb, Transform parentTransform)
+    public bool RemoveLimb(Limb limb, Vector3 position)
     {
         if (m_Limbs.Count == 0)
             return false;
@@ -139,28 +139,10 @@ public class Inventory
         else if (limb is Leg)
             legCount--;
 
-        if (!CreateLimbObject(limb, parentTransform))
+        if (!LimbObjectFactory.Create(limb, position, LimbObjectFactory.PhysicsType.None))
             return false;
 
         limb.inInventory = false;
-
-        return true;
-    }
-
-    private static bool CreateLimbObject(Limb limb, Transform parentTransform)
-    {
-        var newLimbObject =
-                Object.Instantiate(
-                    new GameObject(),
-                    parentTransform.position,
-                    Quaternion.identity) as GameObject;
-
-        if (newLimbObject == null)
-            return false;
-
-        var newLimbBehaviour = newLimbObject.AddComponent<LimbBehaviour>();
-
-        newLimbBehaviour.Init(limb);
 
         return true;
     }

--- a/ArmAndLeg/Assets/Scripts/Items/Limb.cs
+++ b/ArmAndLeg/Assets/Scripts/Items/Limb.cs
@@ -16,9 +16,6 @@ namespace Items
         [SerializeField]
         private float m_MeleeDamage = 1f;
 
-        [SerializeField]
-        private float m_AliveTime = 3f;
-
         public MyBoolEvent inInventoryEvent = new MyBoolEvent();
 
         public bool inInventory
@@ -30,11 +27,6 @@ namespace Items
 
                 inInventoryEvent.Invoke(value);
             }
-        }
-
-        public float aliveTime
-        {
-            get { return m_AliveTime; }
         }
 
         public abstract bool Swing();

--- a/ArmAndLeg/Assets/Scripts/Items/LimbBehaviour.cs
+++ b/ArmAndLeg/Assets/Scripts/Items/LimbBehaviour.cs
@@ -9,17 +9,27 @@ namespace Items
         [SerializeField]
         private Limb m_Limb;
 
-        public bool Init(Limb newLimb)
+        [SerializeField]
+        private float m_AliveTime;
+
+        public float aliveTime
+        {
+            get { return m_AliveTime; }
+            set { m_AliveTime = value; }
+        }
+
+        public bool Init(Limb newLimb, float newAliveTime)
         {
             m_Limb = newLimb;
+            m_AliveTime = newAliveTime;
 
             // Attach to the event
             m_Limb.inInventoryEvent.AddListener(
                 inInventory =>
                 {
                     // If no longer in inventory then start to disappear
-                    if (!inInventory)
-                        StartCoroutine(Disappear());
+                    //if (!inInventory)
+                    //    StartCoroutine(Disappear());
                 });
 
             return true;
@@ -27,7 +37,25 @@ namespace Items
 
         private IEnumerator Disappear()
         {
-            yield return new WaitForSeconds(m_Limb.aliveTime);
+            var time = 0f;
+
+            while (time < m_AliveTime)
+            {
+                time += Time.deltaTime;
+
+                var spriteRenderer = GetComponent<SpriteRenderer>();
+                if (spriteRenderer)
+                {
+                    spriteRenderer.color =
+                        new Color(
+                            spriteRenderer.color.r,
+                            spriteRenderer.color.g,
+                            spriteRenderer.color.b,
+                            spriteRenderer.color.a - 1f / m_AliveTime * Time.deltaTime);
+                }
+
+                yield return false;
+            }
 
             if (!m_Limb.inInventory)
                 Destroy(gameObject);

--- a/ArmAndLeg/Assets/Scripts/LimbObjectFactory.cs
+++ b/ArmAndLeg/Assets/Scripts/LimbObjectFactory.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Linq;
+
+using Items;
+
+using UnityEngine;
+
+using Object = UnityEngine.Object;
+using Random = UnityEngine.Random;
+
+public static class LimbObjectFactory
+{
+    private static LimbObjectFactorySettings s_Settings;
+
+    private static LimbObjectFactorySettings settings
+    {
+        get
+        {
+            if (!s_Settings)
+                s_Settings = Resources.FindObjectsOfTypeAll<LimbObjectFactorySettings>().First();
+
+            return s_Settings;
+        }
+    }
+
+    [Flags]
+    public enum PhysicsType
+    {
+        None = 0,
+
+        Translate = 1 << 0,
+        Rotate = 1 << 1,
+    }
+
+    public static bool Create<T>(T limb, Vector3 position, PhysicsType physicsType) where T : Limb
+    {
+        var newLimbObject =
+            Object.Instantiate(settings.limbPrefab, position, Quaternion.identity) as GameObject;
+
+        if (!newLimbObject)
+            return false;
+
+        EnemyLimbBehaviour matchingEnemyLimb = null;
+        foreach (var enemyLimb in Object.FindObjectsOfType<EnemyLimbBehaviour>())
+            if (enemyLimb.limb == limb)
+                matchingEnemyLimb = enemyLimb;
+
+        if (matchingEnemyLimb)
+        {
+            newLimbObject.transform.position = matchingEnemyLimb.transform.position;
+            newLimbObject.transform.rotation = matchingEnemyLimb.transform.rotation;
+            newLimbObject.transform.localScale = matchingEnemyLimb.transform.localScale;
+        }
+
+        var rigidbody = newLimbObject.GetComponent<Rigidbody2D>();
+        if (rigidbody)
+        {
+            rigidbody.AddForce(
+                new Vector3(
+                    GetTranslationValue(),
+                    GetTranslationValue(),
+                    0f));
+
+            rigidbody.AddTorque(GetRotationValue());
+        }
+
+        var spriteRenderer = newLimbObject.GetComponent<SpriteRenderer>();
+        if (spriteRenderer)
+        {
+            if (matchingEnemyLimb)
+            {
+                var matchingSpriteRenderer = matchingEnemyLimb.GetComponent<SpriteRenderer>();
+                if (matchingSpriteRenderer)
+                {
+                    spriteRenderer.sprite = matchingSpriteRenderer.sprite;
+
+                    spriteRenderer.flipX = matchingSpriteRenderer.flipX;
+                    spriteRenderer.flipY = matchingSpriteRenderer.flipY;
+                }
+            }
+            else
+            {
+                if (limb is Arm)
+                    spriteRenderer.sprite = settings.defaultArmSprite;
+                else if (limb is Leg)
+                    spriteRenderer.sprite = settings.defaultLegSprite;
+            }
+        }
+
+        var newLimbBehaviour = newLimbObject.AddComponent<LimbBehaviour>();
+        newLimbBehaviour.Init(limb, 3f);
+
+        return true;
+    }
+
+    private static float GetTranslationValue()
+    {
+        var isNegative = (int)Mathf.Round(Random.value) == 1;
+
+        var negativeCoefficient = isNegative ? -1 : 1;
+
+        return
+             Random.Range(settings.translationRandomMin, settings.translationRandomMax)
+            * negativeCoefficient;
+    }
+
+    private static float GetRotationValue()
+    {
+        var isNegative = (int)Mathf.Round(Random.value) == 1;
+
+        var negativeCoefficient = isNegative ? -1 : 1;
+
+        return
+            Random.Range(settings.rotationRandomMin, settings.rotationRandomMax)
+            * negativeCoefficient;
+    }
+}
+
+[CreateAssetMenu(fileName = "NewLimbFactorySettings", menuName = "Settings/Limb Factory Settings")]
+public class LimbObjectFactorySettings : ScriptableObject
+{
+    public GameObject limbPrefab;
+
+    [Space]
+    public Sprite defaultArmSprite;
+    public Sprite defaultLegSprite;
+
+    [Space]
+    public float aliveTime;
+
+    [Space]
+    public float translationRandomMin;
+    public float translationRandomMax;
+
+    [Space]
+    public float rotationRandomMin;
+    public float rotationRandomMax;
+}

--- a/ArmAndLeg/Assets/Scripts/LimbObjectFactory.cs.meta
+++ b/ArmAndLeg/Assets/Scripts/LimbObjectFactory.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: dead94e1299db4148b29270c15fa506a
+timeCreated: 1477107349
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ArmAndLeg/Assets/Settings.meta
+++ b/ArmAndLeg/Assets/Settings.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 823b779555dab754fa64e2c398065c27
+folderAsset: yes
+timeCreated: 1477110977
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ArmAndLeg/Assets/Settings/Limb Object Factory Settings.asset
+++ b/ArmAndLeg/Assets/Settings/Limb Object Factory Settings.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Limb Factory Settings
+  m_EditorClassIdentifier: Assembly-CSharp::LimbObjectFactorySettings
+  limbPrefab: {fileID: 1000013572252958, guid: 3f821fcc127ec2049a28a9c0e291df67, type: 2}
+  defaultArmSprite: {fileID: 21300000, guid: 3112124edbf91814cad05089e556bd76, type: 3}
+  defaultLegSprite: {fileID: 21300000, guid: bb831492d360c4b4ba9c04493223bdfb, type: 3}
+  aliveTime: 3
+  translationRandomMin: 500
+  translationRandomMax: 750
+  rotationRandomMin: 250
+  rotationRandomMax: 500

--- a/ArmAndLeg/Assets/Settings/Limb Object Factory Settings.asset.meta
+++ b/ArmAndLeg/Assets/Settings/Limb Object Factory Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36cc56dda6e3329409638e83a79a631d
+timeCreated: 1477110991
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ArmAndLeg/ProjectSettings/ProjectSettings.asset
+++ b/ArmAndLeg/ProjectSettings/ProjectSettings.asset
@@ -408,8 +408,18 @@ PlayerSettings:
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   intPropertyNames:
+  - Android::ScriptingBackend
   - Standalone::ScriptingBackend
+  - WebGL::ScriptingBackend
+  - WebGL::audioCompressionFormat
+  - WebGL::exceptionSupport
+  - WebGL::memorySize
+  Android::ScriptingBackend: 0
   Standalone::ScriptingBackend: 0
+  WebGL::ScriptingBackend: 1
+  WebGL::audioCompressionFormat: 4
+  WebGL::exceptionSupport: 1
+  WebGL::memorySize: 256
   boolPropertyNames:
   - Android::VR::enable
   - Metro::VR::enable
@@ -422,6 +432,9 @@ PlayerSettings:
   - Standalone::VR::enable
   - Tizen::VR::enable
   - WebGL::VR::enable
+  - WebGL::analyzeBuildSize
+  - WebGL::dataCaching
+  - WebGL::useEmbeddedResources
   - WebPlayer::VR::enable
   - WiiU::VR::enable
   - Xbox360::VR::enable
@@ -439,6 +452,9 @@ PlayerSettings:
   Standalone::VR::enable: 0
   Tizen::VR::enable: 0
   WebGL::VR::enable: 0
+  WebGL::analyzeBuildSize: 0
+  WebGL::dataCaching: 0
+  WebGL::useEmbeddedResources: 0
   WebPlayer::VR::enable: 0
   WiiU::VR::enable: 0
   Xbox360::VR::enable: 0
@@ -455,6 +471,9 @@ PlayerSettings:
   - Purchasing_ServiceEnabled::Purchasing_ServiceEnabled
   - UNet_ServiceEnabled::UNet_ServiceEnabled
   - Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled
+  - WebGL::emscriptenArgs
+  - WebGL::template
+  - additionalIl2CppArgs::additionalIl2CppArgs
   Analytics_ServiceEnabled::Analytics_ServiceEnabled: False
   Build_ServiceEnabled::Build_ServiceEnabled: False
   Collab_ServiceEnabled::Collab_ServiceEnabled: False
@@ -464,6 +483,9 @@ PlayerSettings:
   Purchasing_ServiceEnabled::Purchasing_ServiceEnabled: False
   UNet_ServiceEnabled::UNet_ServiceEnabled: False
   Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled: False
+  WebGL::emscriptenArgs: 
+  WebGL::template: APPLICATION:Default
+  additionalIl2CppArgs::additionalIl2CppArgs: 
   vectorPropertyNames:
   - Android::VR::enabledDevices
   - Metro::VR::enabledDevices


### PR DESCRIPTION
An enemy's limbs are considered different from limb that are on the
ground, and those that are in the player's inventory since they are game
objects, but also in someone's inventory. So. They need the component
EnemyLimbBehaviour added to them. This class inherits from monobehaviour
(so it is a component) and it hold a reference to a limb object. This
means that you can give an enemy an already existant limb or create a
new one and then attach it to your enemy. When the enemy pops a limb off
of his inventory, that same limb reference is used to create a new game
object with the component LimbBehaviour at the same position and using
the same sprite as the limb the zombie had on him.

It also flies off in a random direction with a random rotation. This can
be set in 'ArmAndLeg/Assets/Settings/Limb Object Factory Settings.asset'
using the inspector.
