### PR TITLE
Fix for Enemy Limb Pickup

### DIFF
--- a/ArmAndLeg/Assets/Scripts/EnemyController.cs
+++ b/ArmAndLeg/Assets/Scripts/EnemyController.cs
@@ -10,13 +10,13 @@ public class EnemyController : MonoBehaviour
     public GameObject armPrefab;
     public GameObject legPrefab;
 
-    
+
     // Use this for initialization
     void Awake()
     {
         //set components
         m_AudioSource = GetComponent<AudioSource>();
-        
+
     }
     void Start()
     {
@@ -29,28 +29,28 @@ public class EnemyController : MonoBehaviour
 
     IEnumerator CheckDead()
     {
-        
-        while (m_Inventory.limbCount >0)        
+
+        while (m_Inventory.limbCount >0)
             yield return null;
         while (m_HitCounter > 0)
             yield return null;
         DoDead();
-        
+
     }
 
     void DoDead()
     {
         GetComponent<SpriteRenderer>().sprite = DeadSprite;
     }
-   
-    
+
+
     private GameObject BuildLimb(Object template, Limb limb, bool flipX = false, bool flipY = false)
     {
         var obj = Instantiate(template, transform) as GameObject;
         if (!obj)
             return null;
         //check to see if some rando added an EnemyLimbBehaviour to the prefab
-        //or if some 
+        //or if some
         var objComp = obj.GetComponent<EnemyLimbBehaviour>();
         if(!objComp)
             objComp = obj.AddComponent<EnemyLimbBehaviour>();
@@ -73,7 +73,7 @@ public class EnemyController : MonoBehaviour
         {
             m_AudioSource.clip = AudioClips[0];
             m_AudioSource.Play();
-            
+
         }
         else if (m_Inventory.PopLeg(transform.position))
         {
@@ -82,8 +82,8 @@ public class EnemyController : MonoBehaviour
         }
         else
         {
-            m_AudioSource.clip = AudioClips[2];            
-            
+            m_AudioSource.clip = AudioClips[2];
+
             m_HitCounter -= 1;
 
             m_AudioSource.Play();
@@ -102,15 +102,4 @@ public class EnemyController : MonoBehaviour
     }
 
     public Sprite DeadSprite;
-
-    private void OnTriggerStay2D(Collider2D collider)
-    {
-        var limbBehaviour = collider.GetComponent<LimbBehaviour>();
-        if (limbBehaviour && limbBehaviour.canPickUp)
-        {
-            m_Inventory.AddLimb(limbBehaviour.limb);
-            Destroy(limbBehaviour.gameObject);
-        }
-    }
-
 }

--- a/ArmAndLeg/Assets/Scripts/ZombiePlayerController.cs
+++ b/ArmAndLeg/Assets/Scripts/ZombiePlayerController.cs
@@ -12,36 +12,59 @@ public class ZombiePlayerController : MonoBehaviour
     }
     void Start()
     {
+        var LeftArm = new Arm();
+        var RightArm = new Arm();
 
-
-        Arm LeftArm = new Arm();
-        Arm RightArm = new Arm(); 
+        var LeftLeg = new Leg();
+        var RightLeg = new Leg();
 
         m_Inventory.AddLimb(LeftArm);
         m_Inventory.AddLimb(RightArm);
-    }
 
+        m_Inventory.AddLimb(LeftLeg);
+        m_Inventory.AddLimb(RightLeg);
+    }
     // Update is called once per frame
     void Update()
     {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            m_Inventory.AddLimb(new Arm());
+        }
+
         float h = Input.GetAxis("Horizontal");
         float v = Input.GetAxis("Vertical");
-        Vector2 dir = new Vector3(h, v).normalized;
-        Vector2 pos = transform.position; 
 
-        if(Input.GetKeyDown(KeyCode.Space))
-        {
-            m_Inventory = new Inventory();
-        }
+        Vector2 dir = new Vector3(h, v).normalized;
+        Vector2 pos = transform.position;
 
         transform.position = pos + dir * m_Speed * Time.deltaTime;
         float vel = (pos - (Vector2)transform.position).magnitude;
-        GetComponent<SpriteRenderer>().flipY = (v > 0) ? true : false;
-        
+
         m_anim.SetFloat("Speed", vel);
+
+        // UNCOMMENT FOR ANGULAR ROTATION
+
+        //if (h == 0f && v == 0f)
+        //    return;
+
+        //var to = new Vector2(0, -1);
+        //var from = new Vector2(h, v);
+
+        //var angle = Vector2.Angle(from, to);
+        //var cross = Vector3.Cross(from, to);
+
+        //if (cross.z > 0)
+        //    angle = 360 - angle;
+
+        //transform.eulerAngles =
+        //    new Vector3(
+        //        transform.eulerAngles.x,
+        //        transform.eulerAngles.y,
+        //        Mathf.Abs(angle));
     }
 
-    
+
     public float m_Speed;
 
     [SerializeField]
@@ -50,5 +73,15 @@ public class ZombiePlayerController : MonoBehaviour
     public Inventory inventory
     {
         get { return m_Inventory; }
+    }
+
+    private void OnTriggerStay2D(Collider2D collider)
+    {
+        var limbBehaviour = collider.GetComponent<LimbBehaviour>();
+        if (limbBehaviour && limbBehaviour.canPickUp)
+        {
+            m_Inventory.AddLimb(limbBehaviour.limb);
+            Destroy(limbBehaviour.gameObject);
+        }
     }
 }


### PR DESCRIPTION
Enemies no longer pick up their own limbs.

Player now picks up enemy limbs again.

Added code (commented out) to rotate the player sprite based on velocity
